### PR TITLE
Fix anchor icon rendering

### DIFF
--- a/archives/index.html
+++ b/archives/index.html
@@ -10,7 +10,7 @@ title: Archives
 			{% if post.external-url %}
 				<h1>
 					<a href="{{ post.external-url }}">{{ post.title }}</a> 
-					<a class="anchor" href="{{ post.url }}">&#9875;</a>
+					<a class="anchor" href="{{ post.url }}"><i class="icon-anchor"></i></a>
 				</h1>
 			{% else %}
 				<h1><a href="{{ post.url }}">{{ post.title }}</a></h1>


### PR DESCRIPTION
Using chrome on windows the anchor renders as a box on the archive page, so I changed it to the anchor icon that was in the rest of the pages.
