### PR TITLE
prevent <code> tag cramping

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -47,7 +47,7 @@ a:hover {
 	color: #000000;
 }
 
-p { margin-bottom: 15px; }
+p, pre { margin-bottom: 15px; }
 ul, ol { padding: 0 0 18px 30px; }
 ol li, ul li { margin-top: 10px; margin-bottom: 10px; }
 em, i { font-style: italic; }


### PR DESCRIPTION
When <code> tags are nestled between <p>'s, the spacing between the bottom of the code and the top of the next regular paragraph looked a little small.  I duplicated the spacing between regular paragraphs.